### PR TITLE
Added traffic control to net chaos.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.idea
 *.sw[nop]
+*.pyc

--- a/chaos/net.py
+++ b/chaos/net.py
@@ -30,6 +30,9 @@ class FirewallAction:
     @classmethod
     def rule(cls, rule):
         """Gives an action for creating and deleting a given firewall rule."""
+        if rule.startswith('netem'):
+            return cls('tc qdisc add dev eth0 root {}'.format(rule),
+                       'tc qdisc del dev eth0 root')
         return cls("ufw {}".format(rule), "ufw delete {}".format(rule))
 
     @classmethod
@@ -55,7 +58,6 @@ class FirewallChaos(Chaos):
         self.command_str = name
         self.description = description
         self._actions = list(actions)
-        self._actions.append(FirewallAction.enable())
 
     def enable(self):
         for actions in self._actions:
@@ -81,6 +83,13 @@ class Net(ChaosMonkeyBase):
         allow_in_to_any = FirewallAction.rule("allow in to any")
         deny_in_to_any = FirewallAction.rule("deny in to any")
         deny_out_to_any = FirewallAction.rule("deny out to any")
+        delay = FirewallAction.rule(
+            "netem delay 300ms 20ms distribution normal")
+        delay_long = FirewallAction.rule(
+            'netem delay 5s 1s distribution normal')
+        drop = FirewallAction.rule('netem loss 50% 30%')
+        corrupt = FirewallAction.rule('netem corrupt 50% 30%')
+        duplicate = FirewallAction.rule('netem duplicate 50% 30%')
         return [
             FirewallChaos(
                 'deny-all',
@@ -88,12 +97,14 @@ class Net(ChaosMonkeyBase):
                 allow_ssh,
                 deny_in_to_any,
                 deny_out_to_any,
+                FirewallAction.enable()
                 ),
             FirewallChaos(
                 'deny-incoming',
                 'Deny all incoming network traffic except ssh.',
                 allow_ssh,
                 deny_in_to_any,
+                FirewallAction.enable()
                 ),
             FirewallChaos(
                 'deny-outgoing',
@@ -101,23 +112,54 @@ class Net(ChaosMonkeyBase):
                 allow_ssh,
                 deny_out_to_any,
                 allow_in_to_any,
+                FirewallAction.enable()
                 ),
             FirewallChaos(
                 'deny-state-server',
                 'Deny network traffic to the Juju State-Server',
                 FirewallAction.deny_port_rule(37017),
                 allow_in_to_any,
+                FirewallAction.enable()
                 ),
             FirewallChaos(
                 'deny-api-server',
                 'Deny network traffic to the Juju API Server.',
                 FirewallAction.deny_port_rule(17017),
                 allow_in_to_any,
+                FirewallAction.enable()
                 ),
             FirewallChaos(
                 'deny-sys-log',
                 'Deny network traffic to the Juju SysLog.',
                 FirewallAction.deny_port_rule(6514),
                 allow_in_to_any,
+                FirewallAction.enable()
                 ),
+            FirewallChaos(
+                'delay',
+                'Delay network traffic.',
+                delay,
+                ),
+            FirewallChaos(
+                'delay-long',
+                'Delay network traffic.',
+                delay_long,
+                ),
+            FirewallChaos(
+                'drop',
+                'Drop network packets.',
+                drop,
+                ),
+            FirewallChaos(
+                'corrupt',
+                'Corrupt network packets.',
+                corrupt,
+            ),
+            FirewallChaos(
+                'duplicate',
+                'Duplicate network packets.',
+                duplicate,
+            ),
+
+
         ]

--- a/tests/test_net.py
+++ b/tests/test_net.py
@@ -148,7 +148,31 @@ class TestNet(CommonTestBase):
             [disable_call, delete_allow_in_call,
              call(['ufw', 'delete', 'deny', '6514'])])
 
+    def assert_tc(self, cmd, netem):
+        chaos = self.get_net_chaos(cmd)
+        cmd = 'tc qdisc add dev eth0 root netem {}'.format(netem).split(' ')
+        self.assert_calls(chaos.enable, [call(cmd)])
+        self.assert_calls(
+            chaos.disable,
+            [call('tc qdisc del dev eth0 root'.split(' '))])
+
+    def test_delay(self):
+        self.assert_tc('delay', 'delay 300ms 20ms distribution normal')
+
+    def test_delay_long(self):
+        self.assert_tc('delay-long', 'delay 5s 1s distribution normal')
+
+    def test_drop(self):
+        self.assert_tc('drop', 'loss 50% 30%')
+
+    def test_corrupt(self):
+        self.assert_tc('corrupt', 'corrupt 50% 30%')
+
+    def test_duplicate(self):
+        self.assert_tc('duplicate', 'duplicate 50% 30%')
+
 
 def get_all_net_commands():
     return ['deny-all', 'deny-incoming', 'deny-outgoing',  'deny-state-server',
-            'deny-api-server', 'deny-sys-log']
+            'deny-api-server', 'deny-sys-log', 'delay', 'delay-long',
+            'drop', 'corrupt', 'duplicate']

--- a/tests/test_net.py
+++ b/tests/test_net.py
@@ -150,8 +150,9 @@ class TestNet(CommonTestBase):
 
     def assert_tc(self, cmd, netem):
         chaos = self.get_net_chaos(cmd)
-        cmd = 'tc qdisc add dev eth0 root netem {}'.format(netem).split(' ')
-        self.assert_calls(chaos.enable, [call(cmd)])
+        expected = ("tc qdisc add dev eth0 root netem "
+                    "{}".format(netem).split(' '))
+        self.assert_calls(chaos.enable, [call(expected)])
         self.assert_calls(
             chaos.disable,
             [call('tc qdisc del dev eth0 root'.split(' '))])


### PR DESCRIPTION
This branch adds a traffic control to the net chaos. The following commands have been added:
- `delay`: adds 300ms delay to the network traffic.
- `delay-long`: adds 5 seconds delay to the network traffic.
- `drop`: drops about 50% of the network packets.
- `corrupt`: inserts bit error in the network packets.
- `duplicate`: duplicates some of the network packets. 

The `ping` command can be used to test the `delay`, `delay-long` and `duplicate` commands. When the `delay` command is enabled, you should start noticing the ping time increases by 300ms. In case of using `delay-long`, you should notice the ping time increases by 5 seconds. 

Duplicate command produces duplicate ICMP packets with the same sequence number. 
